### PR TITLE
fix(version): Outputs version from package.json

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "nari",
-  "version": "0.0.3",
+  "version": "0.0.4",
   "bin": "./lib/nari",
   "scripts": {
     "build": "rm -rf ./lib && esbuild src/index.ts --sourcemap --bundle --platform=node --target=node18 --external:./cli --outfile=lib/nari '--banner:js=#!/usr/bin/env node' && chmod +x lib/nari && esbuild src/cli/index.ts --sourcemap --bundle --platform=node --target=node18 --outfile=lib/cli.js",

--- a/src/cli/index.ts
+++ b/src/cli/index.ts
@@ -1,19 +1,15 @@
 import { program } from 'commander';
 
-import { add, AddOptions } from "./add";
-import { install } from "./install";
-import { remove } from "./remove";
+import { add, AddOptions } from './add';
+import { install } from './install';
+import { remove } from './remove';
 
-import { TOOL_NAME } from '../constants';
-
-const VERSION = '0.1.0';
+import { TOOL_NAME, VERSION } from '../constants';
 
 export const cli = async () => {
   let exitCode;
 
-  program
-    .name(TOOL_NAME)
-    .version(VERSION);
+  program.name(TOOL_NAME).version(VERSION);
 
   program
     .command('add [packages...]')
@@ -47,7 +43,7 @@ export const cli = async () => {
   program
     .command('run')
     .description('runs a script from the package')
-    .action(async () => { });
+    .action(async () => {});
 
   await program.parseAsync();
 

--- a/src/cli/install/index.ts
+++ b/src/cli/install/index.ts
@@ -3,11 +3,10 @@ import { ensureCacheDirExists } from '../../cache';
 import { resolve } from '../../resolver';
 import { write } from '../../installer';
 import { ResolveOptions } from '../../resolver/resolver';
-import { TOOL_NAME } from '../../constants';
-import metadata from '../../../package.json';
+import { TOOL_NAME, VERSION } from '../../constants';
 
 export const install = async (options?: ResolveOptions): Promise<number> => {
-  console.log(`${TOOL_NAME} install ${metadata.version}`);
+  console.log(`${TOOL_NAME} install ${VERSION}`);
   const resolveStart = Date.now();
   await ensureCacheDirExists();
   const graph = await resolve(options);

--- a/src/constants.ts
+++ b/src/constants.ts
@@ -1,5 +1,7 @@
 import path from 'path';
+import metadata from '../package.json';
 
+export const VERSION = metadata.version;
 export const TOOL_NAME = 'nari';
 export const CACHE_VERSION = `v1`;
 export const NODE_MODULES = 'node_modules';


### PR DESCRIPTION
--version now outputs version field from root `package.json` instead of using hard-coded value