### PR TITLE
fix(add): should prefer ranges before lockTime

### DIFF
--- a/src/cli/add/__test__/add.test.ts
+++ b/src/cli/add/__test__/add.test.ts
@@ -8,10 +8,11 @@ describe('add script', () => {
       workspacePath: '.',
     };
 
-    const time = new Date().toString();
-    const gen = addScript(tree, ['foo']);
+    const timeNow = new Date();
+    const time = timeNow.toString();
+    const gen = addScript(tree, ['foo'], { timeNow });
 
-    expect(gen.next().value).toEqual({ type: AddEventType.GET_METADATA, name: 'foo' });
+    expect(gen.next().value).toEqual({ type: AddEventType.GET_METADATA, name: 'foo', lockTime: timeNow });
     expect(gen.next().value).toEqual({ type: AddEventType.NEXT_METADATA });
     expect(
       gen.next({ name: 'foo', metadata: { versions: { '1.0.1': {} }, time: { '1.0.1': time } } } as PackageMetadata)
@@ -20,6 +21,7 @@ describe('add script', () => {
       type: AddEventType.MODIFY,
       json: {
         dependencies: { foo: '^1.0.1' },
+        lockTime: timeNow.toISOString(),
       },
     });
     expect(gen.next()).toEqual({ done: true });
@@ -31,11 +33,12 @@ describe('add script', () => {
       workspacePath: '.',
     };
 
-    const time = new Date().toString();
-    const gen = addScript(tree, ['foo', '@scope/bar']);
+    const timeNow = new Date();
+    const time = timeNow.toString();
+    const gen = addScript(tree, ['foo', '@scope/bar'], { timeNow });
 
-    expect(gen.next().value).toEqual({ type: AddEventType.GET_METADATA, name: 'foo' });
-    expect(gen.next().value).toEqual({ type: AddEventType.GET_METADATA, name: '@scope/bar' });
+    expect(gen.next().value).toEqual({ type: AddEventType.GET_METADATA, name: 'foo', lockTime: timeNow });
+    expect(gen.next().value).toEqual({ type: AddEventType.GET_METADATA, name: '@scope/bar', lockTime: timeNow });
     expect(gen.next().value).toEqual({ type: AddEventType.NEXT_METADATA });
     expect(
       gen.next({ name: 'foo', metadata: { versions: { '1.0.1': {} }, time: { '1.0.1': time } } } as PackageMetadata)
@@ -50,23 +53,26 @@ describe('add script', () => {
       type: AddEventType.MODIFY,
       json: {
         dependencies: { foo: '^1.0.1', '@scope/bar': '^2.0.1' },
+        lockTime: timeNow.toISOString(),
       },
     });
     expect(gen.next()).toEqual({ done: true });
   });
 
   it('should detect if the project need not be modified when the dependency is of the latest version', () => {
+    const lockTime = new Date();
     const tree: PurePackage = {
       json: {
         dependencies: { foo: '^1.0.1' },
+        lockTime: lockTime.toISOString(),
       },
       workspacePath: '.',
     };
 
-    const time = new Date().toString();
+    const time = lockTime;
     const gen = addScript(tree, ['foo']);
 
-    expect(gen.next().value).toEqual({ type: AddEventType.GET_METADATA, name: 'foo' });
+    expect(gen.next().value).toEqual({ type: AddEventType.GET_METADATA, name: 'foo', lockTime });
     expect(gen.next().value).toEqual({ type: AddEventType.NEXT_METADATA });
     expect(
       gen.next({ name: 'foo', metadata: { versions: { '1.0.1': {} }, time: { '1.0.1': time } } } as PackageMetadata),
@@ -79,10 +85,11 @@ describe('add script', () => {
       workspacePath: '.',
     };
 
-    const time = new Date().toString();
-    const gen = addScript(tree, ['foo'], { optional: true, tilde: true });
+    const timeNow = new Date();
+    const time = timeNow.toString();
+    const gen = addScript(tree, ['foo'], { optional: true, tilde: true, timeNow });
 
-    expect(gen.next().value).toEqual({ type: AddEventType.GET_METADATA, name: 'foo' });
+    expect(gen.next().value).toEqual({ type: AddEventType.GET_METADATA, name: 'foo', lockTime: timeNow });
     expect(gen.next().value).toEqual({ type: AddEventType.NEXT_METADATA });
     expect(
       gen.next({ name: 'foo', metadata: { versions: { '1.0.1': {} }, time: { '1.0.1': time } } } as PackageMetadata)
@@ -91,6 +98,7 @@ describe('add script', () => {
       type: AddEventType.MODIFY,
       json: {
         optionalDependencies: { foo: '~1.0.1' },
+        lockTime: timeNow.toISOString(),
       },
     });
     expect(gen.next()).toEqual({ done: true });
@@ -102,10 +110,11 @@ describe('add script', () => {
       workspacePath: '.',
     };
 
-    const time = new Date().toString();
-    const gen = addScript(tree, ['foo@^1.0.0']);
+    const timeNow = new Date();
+    const time = timeNow.toString();
+    const gen = addScript(tree, ['foo@^1.0.0'], { timeNow });
 
-    expect(gen.next().value).toEqual({ type: AddEventType.GET_METADATA, name: 'foo' });
+    expect(gen.next().value).toEqual({ type: AddEventType.GET_METADATA, name: 'foo', lockTime: timeNow });
     expect(gen.next().value).toEqual({ type: AddEventType.NEXT_METADATA });
     expect(
       gen.next({ name: 'foo', metadata: { versions: { '1.0.1': {} }, time: { '1.0.1': time } } } as PackageMetadata)
@@ -114,6 +123,7 @@ describe('add script', () => {
       type: AddEventType.MODIFY,
       json: {
         dependencies: { foo: '^1.0.0' },
+        lockTime: timeNow.toISOString(),
       },
     });
     expect(gen.next()).toEqual({ done: true });
@@ -125,10 +135,11 @@ describe('add script', () => {
       workspacePath: '.',
     };
 
-    const time = new Date().toString();
-    const gen = addScript(tree, ['fp@npm:foo']);
+    const timeNow = new Date();
+    const time = timeNow.toString();
+    const gen = addScript(tree, ['fp@npm:foo'], { timeNow });
 
-    expect(gen.next().value).toEqual({ type: AddEventType.GET_METADATA, name: 'foo' });
+    expect(gen.next().value).toEqual({ type: AddEventType.GET_METADATA, name: 'foo', lockTime: timeNow });
     expect(gen.next().value).toEqual({ type: AddEventType.NEXT_METADATA });
     expect(
       gen.next({ name: 'foo', metadata: { versions: { '1.0.1': {} }, time: { '1.0.1': time } } } as PackageMetadata)
@@ -137,6 +148,7 @@ describe('add script', () => {
       type: AddEventType.MODIFY,
       json: {
         dependencies: { fp: 'npm:foo:^1.0.1' },
+        lockTime: timeNow.toISOString(),
       },
     });
     expect(gen.next()).toEqual({ done: true });
@@ -148,10 +160,11 @@ describe('add script', () => {
       workspacePath: '.',
     };
 
-    const time = new Date().toString();
+    const timeNow = new Date();
+    const time = timeNow.toString();
     const gen = addScript(tree, ['foo@^1.0.0']);
 
-    expect(gen.next().value).toEqual({ type: AddEventType.GET_METADATA, name: 'foo' });
+    expect(gen.next().value).toEqual({ type: AddEventType.GET_METADATA, name: 'foo', lockTime: timeNow });
     expect(gen.next().value).toEqual({ type: AddEventType.NEXT_METADATA });
     expect(
       gen.next({
@@ -162,8 +175,34 @@ describe('add script', () => {
       type: AddEventType.MODIFY,
       json: {
         devDependencies: { foo: '^1.0.0' },
+        lockTime: timeNow.toISOString(),
       },
     });
     expect(gen.next()).toEqual({ done: true });
+  });
+
+  it('should prefer version before lockTime to the highest version available', () => {
+    const lockTime = new Date('2010-01-01');
+    const tree: PurePackage = {
+      json: { lockTime },
+      workspacePath: '.',
+    };
+
+    const time = new Date('2010-01-02');
+    const gen = addScript(tree, ['foo']);
+    expect(gen.next().value).toEqual({ type: AddEventType.GET_METADATA, name: 'foo', lockTime });
+    expect(gen.next().value).toEqual({ type: AddEventType.NEXT_METADATA });
+    expect(
+      gen.next({
+        name: 'foo',
+        metadata: { versions: { '0.1.0': {}, '1.0.1': {} }, time: { '0.1.0': lockTime, '1.0.1': time } },
+      } as PackageMetadata).value,
+    ).toEqual({
+      type: AddEventType.MODIFY,
+      json: {
+        dependencies: { foo: '^0.1.0' },
+        lockTime,
+      },
+    });
   });
 });

--- a/src/cli/add/addScript.ts
+++ b/src/cli/add/addScript.ts
@@ -1,8 +1,7 @@
-import semver from 'semver';
-
 import { PurePackage } from '../../resolver/workspace';
 import { parseSpecifier } from '../../resolver';
 import { getDependencies } from '../../resolver/dependencies';
+import { resolveRangeFromMeta } from '../../resolver/resolveScript';
 
 export enum AddEventType {
   MODIFY = 'modify',
@@ -15,6 +14,7 @@ export type AddOptions = {
   peer?: boolean;
   optional?: boolean;
   tilde?: boolean;
+  timeNow?: Date;
 };
 
 export type AddEvent =
@@ -25,12 +25,13 @@ export type AddEvent =
   | {
       type: AddEventType.GET_METADATA;
       name: string;
+      lockTime: Date;
     }
   | {
       type: AddEventType.NEXT_METADATA;
     };
 
-export type PackageMetadata = { name: string; metadata: any };
+export type PackageMetadata = { name: string; metadata: any; lockTime: Date };
 
 export const addScript = function* (
   pkg: PurePackage,
@@ -38,10 +39,13 @@ export const addScript = function* (
   opts?: AddOptions,
 ): Generator<AddEvent, any, PackageMetadata | any> {
   const options: AddOptions = opts || {};
+  const parsedSpecifierList = new Set<{ name: string; range: string; alias: string }>();
   const pendingMetadata = new Set<string>();
-  const receivedMetadata = new Map<string, any>();
-  const unresolvedSpecifiers = new Set<{ name: string; range: string; alias: string }>();
+  const unresolvedRanges = new Map<string, Set<string>>();
+  const resolvedRanges = new Map<string, Map<string, string>>();
   const prefix = options.tilde ? `~` : `^`;
+  const now = opts?.timeNow || new Date();
+  const lockTime = pkg.json.lockTime ? new Date(pkg.json.lockTime) : now;
 
   let dependencyType = 'dependencies';
   if (options.dev) {
@@ -54,31 +58,69 @@ export const addScript = function* (
 
   for (const specifier of specifierList) {
     const { name, range, alias } = parseSpecifier(specifier);
+    parsedSpecifierList.add({ name, range, alias });
+  }
+
+  for (const { name, range } of parsedSpecifierList) {
     if (!pendingMetadata.has(name)) {
       pendingMetadata.add(name);
-      yield { type: AddEventType.GET_METADATA, name };
 
-      unresolvedSpecifiers.add({ name, range, alias });
+      yield { type: AddEventType.GET_METADATA, name, lockTime };
+
+      let rangeList = unresolvedRanges.get(name);
+      if (!rangeList) {
+        rangeList = new Set<string>();
+        unresolvedRanges.set(name, rangeList);
+      }
+      rangeList.add(range);
     }
   }
 
-  while (pendingMetadata.size > 0) {
+  while (unresolvedRanges.size > 0) {
     const packageMetadata = yield { type: AddEventType.NEXT_METADATA };
     if (!packageMetadata) {
       throw new Error('Unable to receive packages metadata, aborting...');
     }
 
-    const { name, metadata } = packageMetadata;
-    pendingMetadata.delete(name);
-    receivedMetadata.set(name, metadata);
+    const { name, metadata, lockTime } = packageMetadata;
+    const rangeList = unresolvedRanges.get(name)!;
+    for (const range of rangeList) {
+      const version = resolveRangeFromMeta(metadata, range, lockTime);
+      if (!version) {
+        if (lockTime !== now) {
+          yield { type: AddEventType.GET_METADATA, name, lockTime: now };
+        } else {
+          const availableVersions = Object.keys(metadata.versions);
+          throw new Error(
+            `Unable to resolve ${name}@${range}, ${metadata.name}, available versions: ${availableVersions}`,
+          );
+        }
+      } else {
+        rangeList.delete(range);
+        if (rangeList.size === 0) {
+          unresolvedRanges.delete(name);
+        }
+
+        let rangeToVersion = resolvedRanges.get(name);
+        if (!rangeToVersion) {
+          rangeToVersion = new Map<string, string>();
+          resolvedRanges.set(name, rangeToVersion);
+        }
+        rangeToVersion.set(range, version);
+      }
+    }
   }
 
   let isModified = false;
   const nextJson = structuredClone(pkg.json);
-  for (const { name, range, alias } of unresolvedSpecifiers) {
-    const metadata = receivedMetadata.get(name)!;
-    const availableVersions = Object.keys(metadata.versions);
-    const version = semver.maxSatisfying(availableVersions, range);
+
+  if (!nextJson.lockTime) {
+    nextJson.lockTime = lockTime.toISOString();
+    isModified = true;
+  }
+
+  for (const { name, range, alias } of parsedSpecifierList) {
+    const version = resolvedRanges.get(name)!.get(range)!;
     const targetRange = range !== '' ? range : `${prefix}${version}`;
     const depRange = alias ? `npm:${name}:${targetRange}` : targetRange;
     const dependencies = getDependencies(pkg.json, true);

--- a/src/resolver/resolver.ts
+++ b/src/resolver/resolver.ts
@@ -25,7 +25,7 @@ export const RESOLVE_STATE_FILE = '.resolve-state.json';
 const RESOLVE_STATE_PATH = path.join(NODE_MODULES, RESOLVE_STATE_FILE);
 const RESOLVE_STATE_VERSION = '1';
 
-const getMetadata = async ({ name, lockTime }: { name: string; lockTime?: Date }) => {
+export const getMetadata = async ({ name, lockTime }: { name: string; lockTime: Date }) => {
   let fresh: boolean;
   const cachedMetadata = await getCachedMetadata(name);
   let metadata;
@@ -37,7 +37,7 @@ const getMetadata = async ({ name, lockTime }: { name: string; lockTime?: Date }
     metadata = await downloadMetadata(name, cachedMetadata);
   }
 
-  return { name, metadata, fresh };
+  return { name, metadata, fresh, lockTime };
 };
 
 export const resolve = async (opts?: ResolveOptions) => {


### PR DESCRIPTION
`nari add foo` should prefer adding highest version of foo which existed before `lockTime` so that all project dependencies were within same time epoch when they all existed together.